### PR TITLE
feat: claude cors 우회를 위한 tauri에 stream proxy server 추가 & claude util

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,6 +82,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "atk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +275,9 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cairo-rs"
@@ -609,6 +634,12 @@ dependencies = [
  "quote",
  "syn 2.0.49",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "der"
@@ -1277,6 +1308,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.11",
+ "indexmap 2.2.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
@@ -1317,6 +1367,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 0.2.11",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.11",
 ]
 
 [[package]]
@@ -1414,6 +1488,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
@@ -1431,7 +1516,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1448,6 +1533,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.10",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,9 +1571,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
+ "h2 0.4.3",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.0",
  "httparse",
  "itoa 1.0.10",
  "pin-project-lite",
@@ -1469,13 +1584,26 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.30",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.2.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1493,8 +1621,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body",
- "hyper",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1823,15 +1951,19 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 name = "magic"
 version = "1.0.0"
 dependencies = [
+ "async-stream",
  "base64 0.22.0",
  "chrono",
- "reqwest",
+ "futures-util",
+ "reqwest 0.12.2",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-sql",
  "tauri-plugin-store",
+ "tokio",
+ "warp",
 ]
 
 [[package]]
@@ -1904,6 +2036,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +2070,24 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 0.2.11",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -2750,6 +2910,48 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
@@ -2760,12 +2962,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.3",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.0",
  "http-body-util",
- "hyper",
- "hyper-tls",
+ "hyper 1.2.0",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -2783,10 +2985,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg 0.50.0",
 ]
@@ -3126,6 +3330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3661,6 +3874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd27c04b9543776a972c86ccf70660b517ecabbeced9fb58d8b961a13ad129af"
 dependencies = [
  "anyhow",
+ "bytes",
  "cocoa",
  "dirs-next",
  "embed_plist",
@@ -3680,6 +3894,7 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
+ "reqwest 0.11.27",
  "rfd",
  "semver",
  "serde",
@@ -3986,9 +4201,23 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4010,6 +4239,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4200,10 +4441,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -4341,6 +4610,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.11",
+ "hyper 0.14.30",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4417,6 +4715,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,13 +11,17 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "global-shortcut-all", "fs-all", "dialog-all", "shell-open"] }
+tauri = { version = "1.5", features = [ "http-all", "global-shortcut-all", "fs-all", "dialog-all", "shell-open"] }
 tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
-reqwest = { version = "0.12", features = ["blocking", "json"] }
+reqwest = { version = "0.12", features = ["blocking", "json", "stream"] }
 base64 = "0.22"
+warp = "0.3"
+tokio = { version = "1", features = ["full"] }
+futures-util = "0.3"
+async-stream = "0.3"
 
 [dependencies.tauri-plugin-sql]
 git = "https://github.com/tauri-apps/plugins-workspace"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,12 +1,21 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use serde::Serialize;
 use tauri_plugin_sql::{Migration, MigrationKind};
 use reqwest;
 use base64::{Engine as _, engine::{general_purpose}};
 use std::process::{Command};
 use std::str;
+use warp::{reply::with_header, Filter,sse::Event};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use reqwest::Client;
+use warp::hyper::HeaderMap;
+use std::convert::Infallible;
+use futures_util::{StreamExt};
+use warp::http::header::{HeaderValue,ACCESS_CONTROL_ALLOW_ORIGIN,ACCESS_CONTROL_ALLOW_METHODS,ACCESS_CONTROL_ALLOW_HEADERS};
+use async_stream::stream;
+
 
 #[tauri::command]
 fn toggle_window(window: tauri::Window) {
@@ -102,6 +111,7 @@ fn get_ollama_models() -> Vec<Model> {
     }
 }
 
+// #[tokio::main]
 fn main() {
     let migrations = vec![
         Migration {
@@ -203,6 +213,139 @@ fn main() {
         .invoke_handler(tauri::generate_handler![write_image,toggle_window,get_ollama_version,get_ollama_models])
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_sql::Builder::default().add_migrations("sqlite:magic.db", migrations).build())
+        .setup(|app| {
+            tauri::async_runtime::spawn(async move {
+                let options_route = warp::options()
+                    .map(|| {
+                        warp::reply::with_status(
+                    warp::reply::with_header(
+                        warp::reply::with_header(
+                            warp::reply::with_header(
+                                "OK",
+                                ACCESS_CONTROL_ALLOW_ORIGIN,
+                                HeaderValue::from_static("*")
+                                ),
+                        ACCESS_CONTROL_ALLOW_METHODS,
+                        HeaderValue::from_static("GET, POST, PUT, PATCH, DELETE, OPTIONS")
+                                ),
+                        ACCESS_CONTROL_ALLOW_HEADERS,
+                        HeaderValue::from_static("*")
+                            ),
+                    warp::http::StatusCode::OK
+                        )
+                    }
+                );
+                    
+                let proxy_post = warp::post()
+                    .and(warp::query::<Url>())
+                    .and(warp::body::json())
+                    .and(warp::header::headers_cloned())
+                    .and_then(stream_proxy_handler);
+
+                let routes = options_route.or(proxy_post);
+                
+                warp::serve(routes).run(([127, 0, 0, 1], 17771)).await;
+            });
+
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[derive(Deserialize, Serialize)]
+struct MessageBody {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct RequestBody {
+    model: String,
+    messages: Vec<MessageBody>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct Url {
+    url: String,
+}
+
+async fn stream_proxy_handler(
+    url: Url,
+    body: Option<Value>,
+    headers: HeaderMap,
+) -> Result<impl warp::Reply, Infallible> {
+    let client = Client::new();
+
+    let mut request_builder = client.post(url.url).json(&body.unwrap_or_default());
+    let reqwest_headers = convert_to_reqwest_headers(headers)?;
+for (key, value) in reqwest_headers.iter() {
+    if key == "content-length" || key == "host" || key == "accept-language" || key == "accept-encoding" {
+        continue
+    }
+
+    request_builder = request_builder.header(key, value.clone());
+}
+    let response = request_builder.send().await.unwrap();
+    let event_stream = stream! {
+        let mut stream = response.bytes_stream();
+
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    let data = String::from_utf8_lossy(&bytes);
+                    let data_str = data.to_string();
+                    for line in data_str.lines() {
+                        if line.starts_with("data") {
+                            let d = line.replace("data:", "");
+
+                            yield Ok::<_, Infallible>(Event::default().data(d));
+                            
+                        } else if line.starts_with("event") {
+                            let e = line.replace("event:", "");
+                            yield Ok::<_, Infallible>(Event::default().event(e));
+                            
+                        } else {
+                            if line.trim() == "" {
+                                continue
+                            }
+
+                            yield Ok::<_, Infallible>(Event::default().data(format!(" {}", line)));
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error while reading response chunk: {}", e);
+                    break;
+                }
+            }
+        }
+    };
+
+    let reply = warp::sse::reply(warp::sse::keep_alive().stream(event_stream));
+    let response = with_header(reply, ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+
+    Ok(response)
+}
+
+fn convert_to_reqwest_headers(
+    hyper_headers: HeaderMap,
+) -> Result<reqwest::header::HeaderMap, Infallible> {
+    let mut reqwest_headers = reqwest::header::HeaderMap::new();;
+
+    for (key, value) in hyper_headers.iter() {
+        let reqwest_key = reqwest::header::HeaderName::from_bytes(key.as_str().as_bytes())
+            .unwrap();
+
+        let reqwest_value = reqwest::header::HeaderValue::from_bytes(value.as_bytes())
+            .unwrap();
+
+        reqwest_headers.insert(reqwest_key, reqwest_value);
+    }
+
+    Ok(reqwest_headers)
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,6 +25,9 @@
       },
       "globalShortcut": {
         "all": true
+      },
+      "http": {
+        "all": true
       }
     },
     "windows": [

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -1,0 +1,59 @@
+import { safeParseJSON } from "@/utils/json";
+
+const CORS_PROXY_API_BASE_URL = "http://localhost:17771";
+
+interface CreateMessageStreamParams {
+  apiKey: string;
+  model: string;
+  messages: { role: string; content: string }[];
+  onMessage: (message: string) => void;
+}
+
+export async function createMessageStream({
+  apiKey,
+  onMessage,
+  ...body
+}: CreateMessageStreamParams) {
+  const res = await fetch(
+    `${CORS_PROXY_API_BASE_URL}?url=https://api.anthropic.com/v1/messages`,
+    {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        ...body,
+        max_tokens: 2048,
+        stream: true,
+      }),
+    }
+  );
+  const reader = (res.body as any)?.getReader();
+  const decoder = new TextDecoder();
+  while (true) {
+    const { value, done } = (await reader?.read()) as any;
+    if (done) break;
+
+    const decoded = decoder.decode(value);
+    const data = decoded.split(/\n\n/);
+    for (const d of data) {
+      // 예) event: message_delta/event: message_stop/event: content_block_delta
+      if (d.startsWith("event:")) {
+        continue;
+      }
+
+      const parsed = safeParseJSON(d.replace("data: ", ""));
+      if (parsed?.error) {
+        throw parsed?.error?.message;
+      }
+
+      onMessage(parsed?.delta?.text || "");
+    }
+  }
+}
+
+export const claude = {
+  createMessageStream,
+};


### PR DESCRIPTION
사용법

```typescript
import { claude } from "@/utils/claude";

// ...코드

let text = "";
await claude.createMessageStream({
  apiKey:
    `${caludeApiKey}`,
  model: "claude-3-5-sonnet-20240620",
  messages: [{ role: "user", content: "Hello, world" }],
  onMessage(message) {
    text += message;
  },
});
console.log("!!!!text", text);
```